### PR TITLE
#29 Fix: Sometimes Greenchoice API returns a profile with an empty agreementid, they appear to be useless in this context and are filtered out to prevent Pydantic errors

### DIFF
--- a/custom_components/greenchoice/api.py
+++ b/custom_components/greenchoice/api.py
@@ -112,7 +112,12 @@ class GreenchoiceApi:
 
     async def get_profiles(self) -> list[Profile]:
         profiles_json = await self.request("/api/v2/Profiles/")
-        return [Profile.model_validate(p) for p in profiles_json]
+        _LOGGER.debug(profiles_json)
+        filtered_profiles = [
+            p for p in profiles_json
+            if p.get("agreementId") is not None
+        ]
+        return [Profile.model_validate(p) for p in filtered_profiles]
 
     async def get_meter_readings(self) -> MeterReadings:
         meter_json = await self.request(


### PR DESCRIPTION
Tested this in my environment and this solves my issue