### PR TITLE
Adding the agreement id to the display list.

### DIFF
--- a/custom_components/greenchoice/config_flow.py
+++ b/custom_components/greenchoice/config_flow.py
@@ -157,6 +157,9 @@ class GreenchoiceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if profile.city:
             address_parts.append(profile.city)
 
+        if profile.agreement_id:
+            address_parts.append(f"({profile.agreement_id})")
+
         if address_parts:
             return " ".join(address_parts)
         else:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -135,7 +135,7 @@ async def test_profile_step_creates_entry_without_custom_name(flow, mock_profile
     result = await flow.async_step_profile({CONF_PROFILE: "2222_1111"})
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Greenchoice (Address Street 1 1234AB City)"
+    assert result["title"] == "Greenchoice (Address Street 1 1234AB City (1111))"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is helpful if you have multiple profiles with the same address to select the correct one.